### PR TITLE
fix: New type added

### DIFF
--- a/packages/ai-spine-tools-core/package.json
+++ b/packages/ai-spine-tools-core/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && node scripts/generate-types.js",
     "dev": "rollup -c -w",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/ai-spine-tools-core/scripts/generate-types.js
+++ b/packages/ai-spine-tools-core/scripts/generate-types.js
@@ -14,17 +14,14 @@ let content = fs.readFileSync(typesPath, 'utf8');
 // Add FileInput to the type exports if it's not already there
 if (!content.includes('FileInput')) {
   // Find the line with type exports and add FileInput
-  content = content.replace(
-    /export type \{ ([^}]+) \};/,
-    (match, types) => {
-      const typeList = types.split(', ').map(t => t.trim());
-      if (!typeList.includes('FileInput')) {
-        typeList.push('FileInput');
-        typeList.sort();
-      }
-      return `export type { ${typeList.join(', ')} };`;
+  content = content.replace(/export type \{ ([^}]+) \};/, (match, types) => {
+    const typeList = types.split(', ').map(t => t.trim());
+    if (!typeList.includes('FileInput')) {
+      typeList.push('FileInput');
+      typeList.sort();
     }
-  );
+    return `export type { ${typeList.join(', ')} };`;
+  });
 }
 
 // Write the updated content back

--- a/packages/ai-spine-tools-core/scripts/generate-types.js
+++ b/packages/ai-spine-tools-core/scripts/generate-types.js
@@ -1,0 +1,33 @@
+/**
+ * Custom type generation script for @ai-spine/tools-core
+ * This script adds missing type exports that TypeScript can't automatically generate
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const typesPath = path.join(__dirname, '..', 'dist', 'index.d.ts');
+
+// Read the existing declaration file
+let content = fs.readFileSync(typesPath, 'utf8');
+
+// Add FileInput to the type exports if it's not already there
+if (!content.includes('FileInput')) {
+  // Find the line with type exports and add FileInput
+  content = content.replace(
+    /export type \{ ([^}]+) \};/,
+    (match, types) => {
+      const typeList = types.split(', ').map(t => t.trim());
+      if (!typeList.includes('FileInput')) {
+        typeList.push('FileInput');
+        typeList.sort();
+      }
+      return `export type { ${typeList.join(', ')} };`;
+    }
+  );
+}
+
+// Write the updated content back
+fs.writeFileSync(typesPath, content, 'utf8');
+
+console.log('✅ Type declarations updated with FileInput export');

--- a/packages/ai-spine-tools-core/src/field-builders.d.ts
+++ b/packages/ai-spine-tools-core/src/field-builders.d.ts
@@ -362,12 +362,13 @@ export declare function datetimeField(): DateTimeFieldBuilder;
 /**
  * Create a file input field builder
  */
-export declare function fileField(config?: {
+export declare function fileField(): FileFieldBuilder;
+export declare function fileField(config: {
   required?: boolean;
   description?: string;
   allowedMimeTypes?: string[];
   maxFileSize?: number;
-}): FileFieldBuilder;
+}): ToolInputField;
 /**
  * Create an API key configuration field builder
  */

--- a/packages/ai-spine-tools-core/src/field-builders.ts
+++ b/packages/ai-spine-tools-core/src/field-builders.ts
@@ -679,12 +679,19 @@ export function datetimeField(): DateTimeFieldBuilder {
 /**
  * Create a file input field builder
  */
+export function fileField(): FileFieldBuilder;
+export function fileField(config: {
+  required?: boolean;
+  description?: string;
+  allowedMimeTypes?: string[];
+  maxFileSize?: number;
+}): ToolInputField;
 export function fileField(config?: {
   required?: boolean;
   description?: string;
   allowedMimeTypes?: string[];
   maxFileSize?: number;
-}): FileFieldBuilder {
+}): FileFieldBuilder | ToolInputField {
   const builder = new FileFieldBuilder();
 
   if (config) {
@@ -694,7 +701,7 @@ export function fileField(config?: {
     if (config.maxFileSize) builder.maxSize(config.maxFileSize);
 
     // Return the built field when config is provided for consistency
-    return builder.build() as any;
+    return builder.build();
   }
 
   return builder;

--- a/packages/ai-spine-tools-core/src/index.ts
+++ b/packages/ai-spine-tools-core/src/index.ts
@@ -1,5 +1,6 @@
 // Core types and interfaces
 export * from './types.js';
+export type { FileInput } from './types.js';
 
 // Error classes (exported as values, not types)
 export {

--- a/packages/ai-spine-tools-core/src/types.ts
+++ b/packages/ai-spine-tools-core/src/types.ts
@@ -1,6 +1,37 @@
 // Core type definitions for AI Spine tools
 
 /**
+ * Type helper for file inputs received from the AI Spine API.
+ * Files are automatically processed and encoded in base64 with metadata.
+ *
+ * @example
+ * ```typescript
+ * interface MyToolInput {
+ *   document: FileInput;
+ *   attachments: FileInput[];
+ * }
+ *
+ * // In your execute function:
+ * const document = input.document;
+ * const fileBuffer = Buffer.from(document.content, 'base64');
+ * ```
+ */
+export interface FileInput {
+  /** Original filename */
+  name: string;
+  /** File size in bytes */
+  size: number;
+  /** MIME type of the file */
+  type: string;
+  /** Last modified timestamp (optional) */
+  lastModified?: number;
+  /** File content encoded in base64 */
+  content: string;
+  /** Encoding type (always 'base64') */
+  encoding: string;
+}
+
+/**
  * Metadata information for a tool that describes its identity, capabilities, and maintenance information.
  * This information is used for tool discovery, documentation generation, and runtime verification.
  *


### PR DESCRIPTION
# New type added

This pull request adds support for file input types to the `@ai-spine/tools-core` package, enabling tool authors to define and use file fields in their tool schemas and receive file data in a standardized format. The changes include the introduction of a new `FileInput` type, updates to type exports, improvements to the `fileField` builder, and a custom script to ensure proper type declaration generation.

**File input type support:**

* Added a new `FileInput` interface to `types.ts` to standardize file input handling, including metadata and base64-encoded file content.
* Updated `index.ts` to explicitly export the new `FileInput` type for external usage.

**Type declaration improvements:**

* Added a custom script `scripts/generate-types.js` to automatically inject the `FileInput` type export into the generated type declarations after build, ensuring consumers have access to the new type.
* Modified the build script in `package.json` to run the custom type generation script after building, automating the process.

**Field builder enhancements:**

* Improved the `fileField` builder in `field-builders.ts` to support both builder and built field return types, and ensured consistent return values when configuration is provided. [[1]](diffhunk://#diff-82d109f818df63f52cd375d11a66cbf8abc96156bc4253d815983880d448d3d7R682-R694) [[2]](diffhunk://#diff-82d109f818df63f52cd375d11a66cbf8abc96156bc4253d815983880d448d3d7L697-R704)